### PR TITLE
Add diamond to Singularity container; update README; minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,17 @@ please consult the [docs](https://wgd.readthedocs.io/en/latest/).
 
 ## Singularity container
 
-**Note** this hasn't been updated in a while, it may or may not work.
-
-A singularity container is available for ``wgd``, allowing all to use
-all tools in ``wgd`` except ``wgd syn``, without having to install all
+A Singularity container is available for ``wgd``, allowing to use
+all tools in ``wgd`` without having to install all
 required software on your system. To install Singularity follow
-the instructions [here](https://www.sylabs.io/docs/)
+the instructions [here](https://www.sylabs.io/docs/).
 
-If you have singulaity installed (and you're in the virtual machine when
-running on Windows or Mac), you can run the following to get the container
+If you have Singularity installed (and you're in the virtual machine when
+running on Windows or Mac), you can run the following to get the container:
 
     singularity pull --name wgd.simg shub://arzwa/wgd
 
-Then you can use ``wgd`` as follows
+Then you can use ``wgd`` as follows:
 
     singularity exec wgd.simg wgd <command>
 

--- a/Singularity
+++ b/Singularity
@@ -24,7 +24,7 @@ From: vibpsb/i-adhore
 
 	# install python, git, etc.
 	apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yq install python3-pip python3-tk git \
-	    build-essential mcl ncbi-blast+ muscle mafft prank fasttree phyml
+	    build-essential diamond-aligner mcl ncbi-blast+ muscle mafft prank fasttree phyml
 
 	# get wgd
 	git clone https://github.com/arzwa/wgd.git

--- a/wgd/modeling.py
+++ b/wgd/modeling.py
@@ -253,7 +253,7 @@ def plot_mixture(model, data, ax, l=0, u=5, color='black', alpha=0.2,
         else:
             curve = ss.norm.pdf(
                     x, loc=means[k], scale=np.sqrt(varcs[k])) * weights[k]
-        ax.plot(x, curve, '--k', color='black', alpha=0.4)
+        ax.plot(x, curve, '--k', alpha=0.4)
         if first:
             mix = curve
             first = False

--- a/wgd_cli.py
+++ b/wgd_cli.py
@@ -1024,6 +1024,10 @@ def kde(
     histograms. Not supported for one-vs.-one ortholog Ks distributions (but see
     `wgd viz`).
 
+    Example:
+
+        wgd kde panda.ks
+
     wgd  Copyright (C) 2018 Arthur Zwaenepoel
     This program comes with ABSOLUTELY NO WARRANTY;
     """

--- a/wgd_cli.py
+++ b/wgd_cli.py
@@ -160,16 +160,16 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
 # CLI ENTRY POINT --------------------------------------------------------------
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
+@click.version_option("v1.1", prog_name="wgd", help="Print version number.")
 @click.option(
         '--verbosity', '-v', type=click.Choice(['info', 'debug']),
         default='info', help="Verbosity level, default = info."
 )
 @click.option(
         '--logfile', '-l', default=None,
-        help="File to write logs to (optional)"
+        help="File to write logs to (optional)."
 )
-@click.option('--version', is_flag=True, help="Print version number")
-def cli(verbosity, logfile, version):
+def cli(verbosity, logfile):
     """
     Welcome to the wgd command line interface!
 
@@ -215,10 +215,6 @@ def cli(verbosity, logfile, version):
         with open(os.devnull, "w") as f:
             subprocess.call("taskset -p 0xffffffffffff %d" % os.getpid(),
                             shell=True, stdout=f)
-
-    if version:
-        logging.info("This is wgd v1.1")
-    pass
 
 
 # Check and optionally refactor data -------------------------------------------

--- a/wgd_cli.py
+++ b/wgd_cli.py
@@ -1407,7 +1407,7 @@ def wf1(sequences, output_dir, gff_file, feature, attribute, n_threads):
 
     Example:
 
-        wgd pipeline_1 -gff snail.gff -n 16 -f mRNA -a Parent snail.fasta snail_wgd_out
+        wgd wf1 -gff snail.gff -n 16 -f mRNA -a Parent snail.fasta snail_wgd_out
 
     wgd  Copyright (C) 2018 Arthur Zwaenepoel
     This program comes with ABSOLUTELY NO WARRANTY;
@@ -1450,7 +1450,7 @@ def wf2(sequences, output_dir, n_threads):
 
     Example:
 
-        wgd pipeline_2 -n 8 snail.fasta whale.fasta snail_vs_whale_ks_out
+        wgd wf2 -n 8 snail.fasta whale.fasta snail_vs_whale_ks_out
 
     wgd  Copyright (C) 2018 Arthur Zwaenepoel
     This program comes with ABSOLUTELY NO WARRANTY;

--- a/wgd_cli.py
+++ b/wgd_cli.py
@@ -1278,6 +1278,11 @@ def viz(
 
     more information about bokeh: https://bokeh.pydata.org/en/latest/index.html
 
+    Example:
+
+        $ bokeh serve &
+        $ wgd viz -i -ks panda.ks
+
     wgd  Copyright (C) 2018 Arthur Zwaenepoel
     This program comes with ABSOLUTELY NO WARRANTY;
     """


### PR DESCRIPTION
Hi Arthur,

Here's a follow up pull request.

Main changes:
- `README.md`: removed lines saying that Singularity was not updated for a while.
- `Singularity` recipe file installs `diamond-aligner` in the container since it is required by`wgd dmd`. Tested.

Secondary changes:
- `wgd_cli.py` has now `click.version_option` to print wgd version (before the code was giving an error and exiting)
- `modeling.py` was printing several warning lines complaining about a redundant colour option, so I removed the redundant option.
- `wgd_cli.py`: some commands (e.g. `kde`) had no example command line, so I added one (I find it very helpful when approaching for the first times wgd commands). I also updated the example command line in `wf1` and `wf2` that still had what seems to be an old command name.

I'm available for any discussion around the proposed changes :)

Cheers,
Cecilia